### PR TITLE
Updated GPG and SHA256sum links for v21.10 on download page.

### DIFF
--- a/download.html
+++ b/download.html
@@ -111,7 +111,7 @@
 								</header>
 								<div align="left">
 									<ul>
-										<li>First, Download <a href="https://github.com/archcraft-os/releases/releases/download/v21.09/archcraft-2021.09.25-x86_64.iso.sig">gpg signature</a> and <a href="https://github.com/archcraft-os/releases/releases/download/v21.09/archcraft-2021.09.25-x86_64.iso.sha256sum">sha256sum</a> files. Save them in the same directory as ISO.</li>
+										<li>First, Download <a href="https://github.com/archcraft-os/releases/releases/download/v21.10/archcraft-2021.10.05-x86_64.iso.sig">gpg signature</a> and <a href="https://github.com/archcraft-os/releases/releases/download/v21.10/archcraft-2021.10.05-x86_64.iso.sha256sum">sha256sum</a> files. Save them in the same directory as ISO.</li>
 										<li>Open the terminal and verify the details of the key on keyserver (any one)</li>
 										<pre><code>$ gpg --keyserver hkps://keys.gnupg.net --recv-keys 7DC81F73
 $ gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 7DC81F73


### PR DESCRIPTION
**Change(s)**
* Links to SHA256sum and GPG files updated to match those for v21.10
on download page.

**Reason(s)**
* Links pointed to v21.09 files.