### PR TITLE
Make wiki hyperlinks redirect to wiki intro

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -29,7 +29,7 @@
 							<li><a href="download.html">Download</a></li>
 							<li><a href="flavors.html">Flavors</a></li>
 							<li><a href="gallery.html">Gallery</a></li>
-							<li><a href="https://wiki.archcraft.io" target="_blank">Wiki</a></li>
+							<li><a href="https://wiki.archcraft.io/docs/intro" target="_blank">Wiki</a></li>
 							<li><a href="https://wiki.archcraft.io/news" target="_blank">News</a></li>
 							<li><a href="donate.html" class="active">Donate</a></li>
 						</ul>

--- a/download.html
+++ b/download.html
@@ -29,7 +29,7 @@
 							<li><a href="download.html" class="active">Download</a></li>
 							<li><a href="flavors.html">Flavors</a></li>
 							<li><a href="gallery.html">Gallery</a></li>
-							<li><a href="https://wiki.archcraft.io" target="_blank">Wiki</a></li>
+							<li><a href="https://wiki.archcraft.io/docs/intro" target="_blank">Wiki</a></li>
 							<li><a href="https://wiki.archcraft.io/news" target="_blank">News</a></li>
 							<li><a href="donate.html">Donate</a></li>
 						</ul>

--- a/flavors.html
+++ b/flavors.html
@@ -29,7 +29,7 @@
 							<li><a href="download.html">Download</a></li>
 							<li><a href="flavors.html" class="active">Flavors</a></li>
 							<li><a href="gallery.html">Gallery</a></li>
-							<li><a href="https://wiki.archcraft.io" target="_blank">Wiki</a></li>
+							<li><a href="https://wiki.archcraft.io/docs/intro" target="_blank">Wiki</a></li>
 							<li><a href="https://wiki.archcraft.io/news" target="_blank">News</a></li>
 							<li><a href="donate.html">Donate</a></li>
 						</ul>

--- a/gallery.html
+++ b/gallery.html
@@ -30,7 +30,7 @@
 							<li><a href="download.html">Download</a></li>
 							<li><a href="flavors.html">Flavors</a></li>
 							<li><a href="gallery.html" class="active">Gallery</a></li>
-							<li><a href="https://wiki.archcraft.io" target="_blank">Wiki</a></li>
+							<li><a href="https://wiki.archcraft.io/docs/intro" target="_blank">Wiki</a></li>
 							<li><a href="https://wiki.archcraft.io/news" target="_blank">News</a></li>
 							<li><a href="donate.html">Donate</a></li>
 						</ul>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 							<li><a href="download.html">Download</a></li>
 							<li><a href="flavors.html">Flavors</a></li>
 							<li><a href="gallery.html">Gallery</a></li>
-							<li><a href="https://wiki.archcraft.io" target="_blank">Wiki</a></li>
+							<li><a href="https://wiki.archcraft.io/docs/intro" target="_blank">Wiki</a></li>
 							<li><a href="https://wiki.archcraft.io/news" target="_blank">News</a></li>
 							<li><a href="donate.html">Donate</a></li>
 						</ul>


### PR DESCRIPTION
Why?
Because it gets annoying and also I think it just makes more sense to click on the wiki and go straight to the intro to the wiki. 
Been a bit picky ig but thought i might aswell submit this PR.